### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -74,14 +74,14 @@ Resources:
     Properties:
       CodeUri: cognito-triggers/define-auth-challenge/
       Handler: define-auth-challenge.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
 
   CreateAuthChallenge:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: cognito-triggers/create-auth-challenge/
       Handler: create-auth-challenge.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -95,7 +95,7 @@ Resources:
     Properties:
       CodeUri: cognito-triggers/verify-auth-challenge-response/
       Handler: verify-auth-challenge-response.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -111,7 +111,7 @@ Resources:
     Properties:
       CodeUri: cognito-triggers/pre-sign-up/
       Handler: pre-sign-up.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
   
   RekognitionCollection:
     Type: Custom::CustomResource


### PR DESCRIPTION
CloudFormation templates in amazon-cognito-facial-recognition-auth have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.